### PR TITLE
dev: fix the missing return statement in floyd_cycle_find function

### DIFF
--- a/php/floyd-cycle-find.php
+++ b/php/floyd-cycle-find.php
@@ -29,4 +29,6 @@ function floyd_cycle_find(array $sequence): bool
             $hare -= $length-1;
         }
     }
+    
+    return false;
 }


### PR DESCRIPTION
The function was missing the return statement in case no cycle was found